### PR TITLE
Add exclude-newer to pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,7 @@
 [project]
 name = "vectorization-tutorial"
 channels = ["conda-forge"]
+exclude-newer = "7d"
 platforms = ["linux-64", "linux-aarch64", "win-64", "osx-arm64"]
 
 [tasks]


### PR DESCRIPTION
## Summary

- Set top-level `exclude-newer = "7d"` in `pixi.toml`
- Pin `qc-internal` channel with `exclude-newer = "0d"`
- Keep `conda-forge` as a plain string channel (inherits the top-level `exclude-newer`)